### PR TITLE
Remove dependencies for supporting gitRepo volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,9 @@ RUN clean-install \
   e2fsprogs \
   xfsprogs \
   ethtool \
-  git \
   glusterfs-client \
   iproute2 \
   jq \
-  openssh-client \
   nfs-common \
   socat \
   udev \

--- a/README.md
+++ b/README.md
@@ -22,11 +22,6 @@ Kubelet also requires:
 * `nfs-common` - https://github.com/kubernetes/kubernetes/pull/30320
 * `udev` (`udevadm`)- https://github.com/kubernetes/kubernetes/pull/61357
 
-The following are only required for gitRepo Volumes (deprecated):
-
-* `git` - https://github.com/kubernetes/kubernetes/pull/23407
-* `openssh-client` - https://github.com/kubernetes/kubernetes/pull/54250
-
 ### kubectl
 
 `kubectl` (no dependencies) is also included for convenience (e.g. use already pulled Kubelet image to `kubectl delete node` on preemption)


### PR DESCRIPTION
* Kubernetes gitRepo volumes are deprecated and have reasonable alternatives. Supporting them is not a goal
* gitRepo Kubelet dependencies bloat the image and add to the CVE surface area unnecessarily

Rel: https://kubernetes.io/docs/concepts/storage/volumes/#gitrepo