### PR TITLE
Update debian-iptables base from v12.1.2 to buster-v1.3.0

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -11,7 +11,7 @@ RUN apk add curl && \
   tar xzf node.tar.gz kubernetes/node/bin/kubectl kubernetes/node/bin/kubelet
 
 
-FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-iptables:v12.1.2
+FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-iptables:buster-v1.3.0
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
 
 RUN clean-install \

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -11,7 +11,7 @@ RUN apk add curl && \
   tar xzf node.tar.gz kubernetes/node/bin/kubectl kubernetes/node/bin/kubelet
 
 
-FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-iptables:v12.1.2
+FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-iptables:buster-v1.3.0
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
 
 RUN clean-install \


### PR DESCRIPTION
* https://github.com/kubernetes/release/pull/1540