### PR TITLE
Migrate container image builds to GitHub Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,13 @@
+name: build
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  multiarch:
+    uses: poseidon/fleetlock/.github/workflows/multiarch.yaml@main
+    secrets:
+      QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,17 @@ image-%:
 		--arch $* --override-arch $* \
 		--format=docker .
 
+push: \
+	push-amd64
+	push-arm64
+
+push-%:
+	buildah tag $(LOCAL_REPO):$(VERSION)-$* $(IMAGE_REPO):$(VERSION)-$*
+	buildah push --format v2s2 $(IMAGE_REPO):$(VERSION)-$*
+
+manifest:
+	buildah manifest create $(IMAGE_REPO):$(VERSION)
+	buildah manifest add $(IMAGE_REPO):$(VERSION) docker://$(IMAGE_REPO):$(VERSION)-amd64
+	buildah manifest add --variant v8 $(IMAGE_REPO):$(VERSION) docker://$(IMAGE_REPO):$(VERSION)-arm64
+	buildah manifest inspect $(IMAGE_REPO):$(VERSION)
+	buildah manifest push -f v2s2 $(IMAGE_REPO):$(VERSION) docker://$(IMAGE_REPO):$(VERSION)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Kubelet
 [![Quay](https://img.shields.io/badge/container-quay-green)](https://quay.io/repository/poseidon/kubelet)
 [![Dockerhub](https://img.shields.io/badge/container-dockerhub-blue)](https://hub.docker.com/r/psdn/kubelet)
+[![Workflow](https://github.com/poseidon/kubelet/actions/workflows/build.yaml/badge.svg)](https://github.com/poseidon/kubelet/actions/workflows/build.yaml?query=branch%3Amain)
 [![Sponsors](https://img.shields.io/github/sponsors/poseidon?logo=github)](https://github.com/sponsors/poseidon)
 [![Mastodon](https://img.shields.io/badge/follow-news-6364ff?logo=mastodon)](https://fosstodon.org/@typhoon)
 


### PR DESCRIPTION
* Migrate from the internal Drone server using a GitHub Workflow to perform the multi-arch container image build
* Use self-hosted GitHub runners on ARM64 to perform the ARM64 build step faster that QEMU/KVM emulation
* Mandate approval for all workflow runs from outside contributors since the builds use push credentials and partially run internally