### PR TITLE
Add summary workflow to wait-for-status-checks

### DIFF
--- a/.github/workflows/summary.yaml
+++ b/.github/workflows/summary.yaml
@@ -1,0 +1,8 @@
+name: summary
+on:
+  pull_request:
+jobs:
+  enforce:
+    uses: poseidon/matchbox/.github/workflows/wait-for-status-checks.yaml@main
+    permissions:
+      checks: read


### PR DESCRIPTION
* Use the wait-for-status-checks reusable workflow to wait for all status checks. This can be marked as a required check to enable GitHub auto-merge features