### PR TITLE
Changing debian-iptables sources since gcr now requires access token

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -11,7 +11,7 @@ RUN apk add curl && \
   tar xzf node.tar.gz kubernetes/node/bin/kubectl kubernetes/node/bin/kubelet
 
 
-FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-iptables:bullseye-v1.5.5
+FROM registry.k8s.io/build-image/debian-iptables:bookworm-v1.0.0
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
 
 RUN clean-install --allow-change-held-packages libcap2

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -11,7 +11,7 @@ RUN apk add curl && \
   tar xzf node.tar.gz kubernetes/node/bin/kubectl kubernetes/node/bin/kubelet
 
 
-FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-iptables:bullseye-v1.5.5
+FROM registry.k8s.io/build-image/debian-iptables:bookworm-v1.0.0
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
 
 RUN clean-install --allow-change-held-packages libcap2


### PR DESCRIPTION
Now using the amd64 new debian-iptables bookworm image with k8s v1.35.2 and in works great ;)