### PR TITLE
[codex] Use podman for image builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,27 +3,29 @@ VERSION=$(shell git describe --tags --match=v* --always --dirty)
 LOCAL_REPO?=poseidon/kubelet
 IMAGE_REPO?=quay.io/poseidon/kubelet
 
+PLATFORM_amd64=linux/amd64
+PLATFORM_arm64=linux/arm64/v8
+
 image: \
 	image-amd64 \
 	image-arm64
 
 image-%:
-	buildah bud -f Dockerfile.$* \
+	podman build -f Dockerfile.$* \
 		-t $(LOCAL_REPO):$(VERSION)-$* \
-		--arch $* --override-arch $* \
-		--format=docker .
+		--platform $(PLATFORM_$*) .
 
 push: \
-	push-amd64
+	push-amd64 \
 	push-arm64
 
 push-%:
-	buildah tag $(LOCAL_REPO):$(VERSION)-$* $(IMAGE_REPO):$(VERSION)-$*
-	buildah push --format v2s2 $(IMAGE_REPO):$(VERSION)-$*
+	podman tag $(LOCAL_REPO):$(VERSION)-$* $(IMAGE_REPO):$(VERSION)-$*
+	podman push $(IMAGE_REPO):$(VERSION)-$*
 
 manifest:
-	buildah manifest create $(IMAGE_REPO):$(VERSION)
-	buildah manifest add $(IMAGE_REPO):$(VERSION) docker://$(IMAGE_REPO):$(VERSION)-amd64
-	buildah manifest add --variant v8 $(IMAGE_REPO):$(VERSION) docker://$(IMAGE_REPO):$(VERSION)-arm64
-	buildah manifest inspect $(IMAGE_REPO):$(VERSION)
-	buildah manifest push -f v2s2 $(IMAGE_REPO):$(VERSION) docker://$(IMAGE_REPO):$(VERSION)
+	podman manifest create $(IMAGE_REPO):$(VERSION)
+	podman manifest add $(IMAGE_REPO):$(VERSION) docker://$(IMAGE_REPO):$(VERSION)-amd64
+	podman manifest add $(IMAGE_REPO):$(VERSION) docker://$(IMAGE_REPO):$(VERSION)-arm64
+	podman manifest inspect $(IMAGE_REPO):$(VERSION)
+	podman manifest push $(IMAGE_REPO):$(VERSION) docker://$(IMAGE_REPO):$(VERSION)


### PR DESCRIPTION
## Summary

* Convert image build push and manifest targets from buildah to podman
* Use explicit linux platforms for amd64 and arm64 image builds
* Fix the aggregate push target to publish both architecture tags

## Verify

* `make -n image push manifest`
* `git diff --check`
* `rg --hidden -n "buildah" .`
* User validated image builds locally
